### PR TITLE
browserify.cmd to get things bundling!

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -116,7 +116,7 @@ docpadConfig = {
 			# Bundle the scripts the editor uses together
 			commands = [
 				[
-					"#{rootPath}/node_modules/.bin/browserify"
+					"#{rootPath}/node_modules/.bin/browserify.cmd"
 					"-i", "backbone"
 					"-i", "exoskeleton"
 					"-i", "underscore"


### PR DESCRIPTION
As per @SteveMCArthur's patch here: https://github.com/docpad/gui/issues/29

Otherwise this happens:

```
$ docpad run
info: Welcome to DocPad v6.59.6 (local installation: c:\Users\Mikeumus\Desktop\D
ocport\Development\WebWrite\Development\inlinegui\node_modules\docpad)
info: Contribute: http://docpad.org/docs/contribute
info: Plugins: coffeekup, coffeescript, eco, ghpages, livereload, marked, partia
ls, stylus, text, umd
info: Environment: development
info: DocPad listening to http://0.0.0.0:9778/ on directory c:\Users\Mikeumus\De
sktop\Docport\Development\WebWrite\Development\inlinegui\out
info: LiveReload listening to new socket on channel /docpad-livereload
info: Generating...
info: Generated 52/54 files in 5.457 seconds
info: Watching setup starting...
info: Watching setup
info: The action completed successfully
notice: 404 Not Found: /scripts/app-bundled.js
info: Generating...
info: Generated 11/54 files in 3.677 seconds
```

Leaving localhost:9778 blank as a result. No errors yet as a result of not also adding '.cmd' to the end of line 129.
