### PR TITLE
add missing backbone dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "docpad": "~6.64.2",
+    "backbone": "~1.1.2",
     "docpad-plugin-coffeescript": "~2.4.0",
     "docpad-plugin-eco": "~2.0.3",
     "docpad-plugin-marked": "~2.2.0",


### PR DESCRIPTION
Minor change. Noticed that there was an error after cloning the repository and trying to run it.
